### PR TITLE
Hotpotqa dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+venv
+pyproject.toml
+
+*__pycache__*
+*egg-info*

--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ This will set up a virtual environment using Python 3.10 and install all the dep
     HF_TOKEN=your_huggingface_token
     HF_HOME=/path/to/your/huggingface/cache
     ```
+
+## Data
+
+### Inspection
+
+To visibly check whether the RAG questions of a dataset can be answered by the corresponding context, run the following command:
+
+    python3 -m src.inspect.inspect_spans -d <dataset_name> -m <max_samples>
+
+The dataset names can be found in the file itself.  
+The file can be used for every dataset that outputs the common `EvalSample` format.

--- a/src/data_handler/hotpot_qa_data_handler.py
+++ b/src/data_handler/hotpot_qa_data_handler.py
@@ -17,7 +17,7 @@ class HotpotQADataHandler(DataHandler):
 
     dataset_name : str = "TIGER-Lab/LongRAG"
     subset: str = "hotpot_qa"
-    split: Literal["full", "subset_1000"] = "full"  # "full" | "subset_1000"
+    split: Literal["full", "subset_1000"] = "full"
 
     def load_data(self) -> list[EvalSample]:
         dataset = load_dataset(self.dataset_name, name=self.subset, split=self.split, streaming=True)

--- a/src/data_handler/hotpot_qa_data_handler.py
+++ b/src/data_handler/hotpot_qa_data_handler.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from typing import Iterator, Literal
 from urllib.request import DataHandler
 from datasets import load_dataset, Dataset
 from tqdm import tqdm
@@ -13,12 +13,11 @@ class HotpotQADataHandler(DataHandler):
 
         About 2000 out of 8000 samples are removed when setting remove_incomplete_samples to True.
         """
-        super().__init__()
         self.remove_incomplete_samples = remove_incomplete_samples
 
     dataset_name : str = "TIGER-Lab/LongRAG"
     subset: str = "hotpot_qa"
-    split: str = "full"  # "full" | "subset_1000"
+    split: Literal["full", "subset_1000"] = "full"  # "full" | "subset_1000"
 
     def load_data(self) -> list[EvalSample]:
         dataset = load_dataset(self.dataset_name, name=self.subset, split=self.split, streaming=True)

--- a/src/data_handler/hotpot_qa_data_handler.py
+++ b/src/data_handler/hotpot_qa_data_handler.py
@@ -1,0 +1,77 @@
+from typing import Iterator
+from urllib.request import DataHandler
+from datasets import load_dataset, Dataset
+from tqdm import tqdm
+
+from src.dto.dto import EvalSample, Answer, Span
+
+
+class HotpotQADataHandler(DataHandler):
+    def __init__(self, remove_incomplete_samples: bool = True):
+        """
+        :param remove_incomplete_samples: If True, samples with just 1 span information are removed.
+
+        About 2000 out of 8000 samples are removed when setting remove_incomplete_samples to True.
+        """
+        super().__init__()
+        self.remove_incomplete_samples = remove_incomplete_samples
+
+    dataset_name : str = "TIGER-Lab/LongRAG"
+    subset: str = "hotpot_qa"
+    split: str = "full"  # "full" | "subset_1000"
+
+    def load_data(self) -> list[EvalSample]:
+        dataset = load_dataset(self.dataset_name, name=self.subset, split=self.split, streaming=True)
+        return self._extract_relevant_data_from_dict(dataset)
+
+    def _extract_relevant_data_from_dict(self, dataset: Dataset) -> Iterator[EvalSample]:
+        for sample in dataset:
+            spans = self._get_answer_spans(document=sample["context"], span_names=sample["sp"])
+
+            if spans is not None:
+                eval_sample = EvalSample(document_id=str(sample["query_id"]), document=sample["context"])
+                eval_sample.questions = [sample["query"]]
+
+                answers = [Answer(answer=sample["answer"][0], spans=spans)]
+                eval_sample.answers = answers
+                yield eval_sample
+
+    def _get_answer_spans(self, document: dict, span_names: list[str]) -> list[Span] | None:
+        spans = []
+
+        title_str = "Title: "
+        title_str_len = len(title_str)
+
+        for span_name in span_names:
+            title_plus_span_name = title_str + span_name + "\n"
+
+            # Check that the span identifier has a unique occurrence in the document.
+            if document.count(title_plus_span_name) < 1:
+                if self.remove_incomplete_samples:
+                    return None
+                else:
+                    continue
+            elif document.count(title_plus_span_name) > 1:
+                raise ValueError("The span name is found multiple times in the document.")
+
+            title_plus_span_name_start = document.index(title_plus_span_name)
+            title_plus_span_name_end = title_plus_span_name_start + len(title_plus_span_name)
+
+            start = title_plus_span_name_end
+            end = start + 1
+            for _char in document[start:]:
+                if document[end:end + title_str_len] == title_str:
+                    break
+                end += 1
+
+            spans.append(Span(start=start, end=end))
+        return spans
+
+
+if __name__ == "__main__":
+
+    data_handler = HotpotQADataHandler()
+    data = data_handler.load_data()
+
+    for sample in tqdm(data):
+        print(sample)

--- a/src/dto/dto.py
+++ b/src/dto/dto.py
@@ -3,10 +3,16 @@ from typing import Optional
 from pydantic import BaseModel
 
 
+class Span(BaseModel):
+    start: int
+    end: int
+
+
 class Answer(BaseModel):
     answer: str
     start: Optional[int] = None
     end: Optional[int] = None
+    spans: Optional[list[Span]] = None
 
 
 class EvalSample(BaseModel):

--- a/src/inspect/inspect_spans.py
+++ b/src/inspect/inspect_spans.py
@@ -1,0 +1,43 @@
+import argparse
+
+from src.data_handler.hotpot_qa_data_handler import HotpotQADataHandler
+from src.data_handler.narrative_qa_data_handler import NarrativeQADataHandler
+
+dataset_factory = {
+    "TIGER-Lab/LongRAG": HotpotQADataHandler,
+    "deepmind/narrativeqa": NarrativeQADataHandler,
+}
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset_name", "-d", type=str, default="TIGER-Lab/LongRAG")
+    parser.add_argument("--max_samples", "-m", type=int, default=5)
+
+    args = parser.parse_args()
+    
+    dataset_class = dataset_factory[args.dataset_name]
+    data_handler = dataset_class()
+    data = data_handler.load_data()
+
+    for num, sample in enumerate(data):
+        if num > args.max_samples:
+            break
+
+        spans = sample.answers[0].spans
+        for span_num, span in enumerate(spans):
+            question = sample.questions[0]
+            anwer = sample.answers[0].answer
+            document = sample.document
+            answer_span = document[span.start:span.end]
+
+            print(f"Sample {num}")
+            print(f"Span {span_num}")
+            print(f"Question: {question}")
+            print(f"Answer: {anwer}")
+            print()
+            print(f"Answer: {answer_span}")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I did the following things:

1. HotpotQA dataset

- dataset can now be used 
- answer spans are generated
- about 2000/8000 samples can be skipped because they contain incomplete context to answer the questions

2. Multiple answer spans are now allowed

- NOTE: other datasets will have to be adapted to that

3. Inspection tool to visually inspect if answer spans can answer given question (usage: see readme)