### PR TITLE
Load narrativeQA dataset in streaming mode

### DIFF
--- a/src/data_handler/narrative_qa_data_handler.py
+++ b/src/data_handler/narrative_qa_data_handler.py
@@ -11,7 +11,7 @@ class NarrativeQADataHandler(DataHandler):
     dataset_name: str = "deepmind/narrativeqa"
 
     def load_data(self, limit: int) -> List[EvalSample]:
-        ds = load_dataset(self.dataset_name, streaming=True)  # todo implement streaming depending on limit
+        ds = load_dataset(self.dataset_name, streaming=True)
         result = []
         counter = 0
         for dataset in ds.values():


### PR DESCRIPTION
I had to change the narrativeqa dataset loading to streaming, which resulted in some tiny changes to the remaining class.

The reason was that I have only 16GB CPU RAM on my FEC VM.
The program was killed all the time.

Would it be ok for you to just always load the dataset in streaming mode?
It should still be cached on disk so there shouldn't be much of a performance loss.