### PR TITLE
Evaluate by single question

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ pyproject.toml
 
 *__pycache__*
 *egg-info*
+
+.scribbles
+.vscode

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -48,6 +48,14 @@ class EvaluatorConfig(BaseModel):
     output_dir: str = "output"
 
 
+class DocumentEvaluatorConfig(EvaluatorConfig):
+    ...
+
+
+class QuestionEvaluatorConfig(EvaluatorConfig):
+    ...
+
+
 class DataHandlerConfig(BaseModel, ABC):
     ...
 

--- a/src/dto/dto.py
+++ b/src/dto/dto.py
@@ -30,9 +30,17 @@ class RetrieverResult(BaseModel):
 
 class EvalResult(BaseModel):
     recall_at_k: List[float]
+
+
+class DocumentEvalResult(EvalResult):
     eval_sample: EvalSample
     retriever_results: List[RetrieverResult]
 
+
+class QuestionEvalResult(EvalResult):
+    document_id: str
+    question: str
+    
 
 class AverageDocResult(BaseModel):
     average_recall_at_k: List[float]

--- a/src/evaluator/document_evaluator.py
+++ b/src/evaluator/document_evaluator.py
@@ -1,0 +1,25 @@
+from typing import List
+
+from src.config.config import EvaluatorConfig
+from src.dto.dto import DocumentEvalResult
+from src.dto.dto import EvalSample, RetrieverResult
+from src.evaluator.evaluator import Evaluator
+from src.utils import mean_of_lists
+
+
+class DocumentEvaluator(Evaluator):
+    def evaluate(self, eval_sample: EvalSample, retrieved_paragraphs: List[RetrieverResult], k:int) -> DocumentEvalResult:
+        """
+        Evaluates the retrieval performance of the retriever model by comparing the predicted paragraphs
+        """
+        recalls_for_all_questions = []
+        for question, answer, retrieved_paragraph in zip(eval_sample.questions, eval_sample.answers,
+                                                         retrieved_paragraphs):
+            recalls_for_all_questions.append(self.recall_at_k(answer.answer, k, retrieved_paragraph.paragraphs))
+        mean_recalls_at_k = mean_of_lists(recalls_for_all_questions)
+        result = DocumentEvalResult(
+            recall_at_k=mean_recalls_at_k,
+            eval_sample=eval_sample,
+            retriever_results=retrieved_paragraphs,
+        )
+        return result

--- a/src/evaluator/evaluator.py
+++ b/src/evaluator/evaluator.py
@@ -1,30 +1,19 @@
+from abc import ABC, abstractmethod
 from typing import List
 
 from src.config.config import EvaluatorConfig
-from src.dto.dto import EvalResult
+from src.dto.dto import DocumentEvalResult
 from src.dto.dto import EvalSample, RetrieverResult
-from src.utils import create_list, mean_of_lists
+from src.utils import create_list
 
 
-class Evaluator:
+class Evaluator(ABC):
     def __init__(self, evaluator_config: EvaluatorConfig):
         self.evaluator_config = evaluator_config
 
-    def evaluate(self, eval_sample: EvalSample, retrieved_paragraphs: List[RetrieverResult], k:int) -> EvalResult:
-        """
-        Evaluates the retrieval performance of the retriever model by comparing the predicted paragraphs
-        """
-        recalls_for_all_questions = []
-        for question, answer, retrieved_paragraph in zip(eval_sample.questions, eval_sample.answers,
-                                                         retrieved_paragraphs):
-            recalls_for_all_questions.append(self.recall_at_k(answer.answer, k, retrieved_paragraph.paragraphs))
-        mean_recalls_at_k = mean_of_lists(recalls_for_all_questions)
-        result = EvalResult(
-            recall_at_k=mean_recalls_at_k,
-            eval_sample=eval_sample,
-            retriever_results=retrieved_paragraphs,
-        )
-        return result
+    @abstractmethod
+    def evaluate(self, eval_sample: EvalSample, retrieved_paragraphs: List[RetrieverResult], k:int) -> DocumentEvalResult:
+        pass
 
     def recall_at_k(self, answer: str, k: int, retrieved_paragraphs: List[str]) -> List[int]:
         recalls = []

--- a/src/evaluator/post_evaluate.py
+++ b/src/evaluator/post_evaluate.py
@@ -1,0 +1,62 @@
+import json
+import os
+
+from src.config.config import JsonReaderConfig, QuestionEvaluatorConfig
+from src.dto.dto import AverageDocResult, QuestionEvalResult
+from src.evaluator.question_evaluator import QuestionEvaluator
+from src.json_reader.json_reader import JsonReader
+from src.utils import mean_of_lists
+
+def post_evaluate_questions():
+    """
+    Reads all JSON files with DocumentEvalResults.
+    Parses those results and computes the average recall at k for all questions.
+    """
+    print(os.getcwd())
+    evaluator_config = QuestionEvaluatorConfig()
+    question_evaluator = QuestionEvaluator(evaluator_config)
+    
+    json_reader = JsonReader(config=JsonReaderConfig())
+    json_data = json_reader.read_jsons_from_directory()
+
+    for file_path, exp_data in json_data.items():
+        question_eval_results = []
+        for doc in exp_data:
+            document_id = doc["eval_sample"]["document_id"]
+            k = len(doc["recall_at_k"])
+            for retriever_result, answer_data in zip(doc["retriever_results"], doc["eval_sample"]["answers"]):
+                question = retriever_result["question"]
+                answer = answer_data["answer"]
+                paragraphs = retriever_result["paragraphs"]
+
+                question_eval_result = question_evaluator.evaluate(
+                    document_id=document_id,
+                    question=question,
+                    answer=answer,
+                    paragraphs=paragraphs,
+                    k=k,
+                )
+                
+                question_eval_results.append(question_eval_result)
+
+        write_json(filepath=file_path.replace(".json", "_question_eval.json"), data=[result.model_dump() for result in question_eval_results])
+        average_recall = _compute_average_recall(question_eval_results)
+        write_json(filepath=file_path.replace(".json", "_question_average_scores.json"), data=average_recall.model_dump())
+
+
+def _compute_average_recall(eval_results: list[QuestionEvalResult]) -> AverageDocResult:
+    """Is used both for DocumentEvalResult and QuestionEvalResult."""
+    list_of_recalls = [eval_result.recall_at_k for eval_result in eval_results]
+    result = AverageDocResult(
+        average_recall_at_k=mean_of_lists(list_of_recalls),
+    )
+    return result
+        
+
+def write_json(filepath: str, data: dict):
+    with open(filepath, "w") as f:
+        json.dump(data, f, indent=4, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    post_evaluate_questions()

--- a/src/evaluator/question_evaluator.py
+++ b/src/evaluator/question_evaluator.py
@@ -1,0 +1,20 @@
+from typing import List
+
+from src.config.config import EvaluatorConfig
+from src.dto.dto import RetrieverResult, QuestionEvalResult
+from src.evaluator.document_evaluator import Evaluator
+
+
+class QuestionEvaluator(Evaluator):
+    def evaluate(self,document_id: str, question: str, answer: str, retriever_result: List[RetrieverResult], k:int) -> List[int]:
+        """
+        Evaluates the retrieval performance of the retriever model for a single question.
+        """
+        recall_at_k = self.recall_at_k(answer, k, retriever_result.paragraphs)
+
+        eval_result = QuestionEvalResult(
+            document_id=document_id,
+            question=question,
+            recall_at_k=recall_at_k,
+        )
+        return eval_result

--- a/src/evaluator/question_evaluator.py
+++ b/src/evaluator/question_evaluator.py
@@ -1,16 +1,15 @@
 from typing import List
 
-from src.config.config import EvaluatorConfig
-from src.dto.dto import RetrieverResult, QuestionEvalResult
+from src.dto.dto import QuestionEvalResult
 from src.evaluator.document_evaluator import Evaluator
 
 
 class QuestionEvaluator(Evaluator):
-    def evaluate(self,document_id: str, question: str, answer: str, retriever_result: List[RetrieverResult], k:int) -> List[int]:
+    def evaluate(self,document_id: str, question: str, answer: str, paragraphs: List[str], k:int) -> List[int]:
         """
         Evaluates the retrieval performance of the retriever model for a single question.
         """
-        recall_at_k = self.recall_at_k(answer, k, retriever_result.paragraphs)
+        recall_at_k = self.recall_at_k(answer, k, paragraphs)
 
         eval_result = QuestionEvalResult(
             document_id=document_id,

--- a/src/evaluator/question_evaluator.py
+++ b/src/evaluator/question_evaluator.py
@@ -5,7 +5,7 @@ from src.evaluator.document_evaluator import Evaluator
 
 
 class QuestionEvaluator(Evaluator):
-    def evaluate(self,document_id: str, question: str, answer: str, paragraphs: List[str], k:int) -> List[int]:
+    def evaluate(self, document_id: str, question: str, answer: str, paragraphs: List[str], k:int) -> List[int]:
         """
         Evaluates the retrieval performance of the retriever model for a single question.
         """

--- a/src/factory/evaluator_factory.py
+++ b/src/factory/evaluator_factory.py
@@ -1,8 +1,13 @@
-from src.config.config import EvaluatorConfig
+from src.config.config import DocumentEvaluatorConfig, EvaluatorConfig, QuestionEvaluatorConfig
+from src.evaluator.document_evaluator import DocumentEvaluator
 from src.evaluator.evaluator import Evaluator
+from src.evaluator.question_evaluator import QuestionEvaluator
 
 
 class EvaluatorFactory:
     @staticmethod
     def create(evaluator_config: EvaluatorConfig) -> Evaluator:
-        return Evaluator(evaluator_config=evaluator_config)
+        if isinstance(evaluator_config, DocumentEvaluatorConfig):
+            return DocumentEvaluator(evaluator_config=evaluator_config)
+        elif isinstance(evaluator_config, QuestionEvaluatorConfig):
+            return QuestionEvaluator(evaluator_config=evaluator_config)

--- a/src/json_reader/json_reader.py
+++ b/src/json_reader/json_reader.py
@@ -15,7 +15,7 @@ class JsonReader:
           A dictionary of JSON filenames mapped to a list of evaluation samples.
         """
         json_files = [f for f in os.listdir(self._config.json_dir) if
-                      f.endswith('.json') and "configs.json" not in f and "scores.json" not in f]
+                      f.endswith('.json') and "configs.json" not in f and "scores.json" not in f and "question_eval.json" not in f]
         json_data = {}
         for file in json_files:
             file_path = os.path.join(self._config.json_dir, file)

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -86,7 +86,7 @@ class Service:
             document_eval_result = self.document_evaluator.evaluate(eval_sample=sample, retrieved_paragraphs=doc_results,
                                              k=self.vector_db_config.similarity_top_k)
             document_eval_results.append(document_eval_result)
-            self._save_eval_result(eval_result=document_eval_result, file_path=directory)
+            # self._save_eval_result(eval_result=document_eval_result, file_path=directory)  todo: uncomment if you want to save the results for each document
         document_averages = self._compute_average_recall(document_eval_results)
         question_averages = self._compute_average_recall(question_eval_results)
         self._save_average_recall(filename=directory.replace(".json", "_average_scores.json"), doc_result=document_averages)

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -5,7 +5,7 @@ from typing import List
 from llama_index.core import Document
 from tqdm import tqdm
 
-from src.config.config import TokenSplitterConfig, EvaluatorConfig, EmbedModelConfig, VectorDBConfig, \
+from src.config.config import TokenSplitterConfig, DocumentEvaluatorConfig, QuestionEvaluatorConfig,  EmbedModelConfig, VectorDBConfig, \
     DataHandlerConfig, SplitterConfig
 from src.dto.dto import RetrieverResult, EvalSample, EvalResult, AverageDocResult
 from src.factory.data_handler_config_factory import DataHandlerConfigFactory
@@ -20,7 +20,8 @@ from src.vector_db.vector_db import VectorDB
 class Service:
     def __init__(self,
                  splitter_configs: List[SplitterConfig],
-                 evaluator_config: EvaluatorConfig,
+                 document_evaluator_config: DocumentEvaluatorConfig,
+                 question_evaluator_config: QuestionEvaluatorConfig,
                  embed_model_config: EmbedModelConfig,
                  data_handler_config: DataHandlerConfig,
                  vector_db_config: VectorDBConfig,
@@ -28,19 +29,21 @@ class Service:
 
         # to save all configs to json
         self.configs = [
-            evaluator_config,
+            document_evaluator_config,
+            question_evaluator_config,
             embed_model_config,
             data_handler_config,
             vector_db_config,
         ]
         print(f"Running with configs: {self.configs}")
-
+        
         # objects are instantiated later
         self.vector_db_config = vector_db_config
         self.splitter_configs = splitter_configs
 
         # objects are instantiated here
-        self.evaluator = EvaluatorFactory.create(evaluator_config=evaluator_config)
+        self.document_evaluator = EvaluatorFactory.create(evaluator_config=document_evaluator_config)
+        self.question_evaluator = EvaluatorFactory.create(evaluator_config=question_evaluator_config)
         self.data_handler = DataHandlerFactory.create(data_handler_config=data_handler_config)
         # data is loaded here since it is then used for different chunk sizes
         self.data: List[EvalSample] = self.data_handler.load_data(limit=self.evaluator.evaluator_config.eval_limit)
@@ -51,9 +54,10 @@ class Service:
         for splitter_config in self.splitter_configs:
             self.run_with_one_text_splitter(splitter_config=splitter_config)
 
-    def run_with_one_text_splitter(self, splitter_config: SplitterConfig) -> List[EvalResult]:
+    def run_with_one_text_splitter(self, splitter_config: SplitterConfig) -> List[DocumentEvalResult]:
         text_splitter = SplitterFactory.create(splitter_config=splitter_config)
-        eval_results = []
+        document_eval_results = []
+        question_eval_results = []
         directory = self._construct_dir(text_splitter=text_splitter)
         self._save_all_configs(filename=directory.replace(".json", "_configs.json"), splitter_config=splitter_config)
         for sample in tqdm(
@@ -67,13 +71,27 @@ class Service:
                 retrieved_documents = self._retrieve(query=question, vector_db=vector_db, answer=answer.answer,
                                                      document_id=sample.document_id)
                 doc_results.append(retrieved_documents)
-            result = self.evaluator.evaluate(eval_sample=sample, retrieved_paragraphs=doc_results,
+
+                # Evaluate single question.
+                question_eval_result = self.question_evaluator.evaluate(
+                    sample.document_id,
+                    question,
+                    answer=answer.answer,
+                    retriever_result=retrieved_documents,
+                    k=self.vector_db_config.similarity_top_k,
+                )
+                self._save_eval_result(eval_result=question_eval_result, file_path=directory.replace(".json", "_question_eval.json"))
+                question_eval_results.append(question_eval_result)
+
+            document_eval_result = self.document_evaluator.evaluate(eval_sample=sample, retrieved_paragraphs=doc_results,
                                              k=self.vector_db_config.similarity_top_k)
-            eval_results.append(result)
+            document_eval_results.append(document_eval_result)
             # self.save(eval_result=result, file_path=directory) # todo: uncomment this line to save results
-        averages = self._compute_average_recall(eval_results)
-        self._save_average_recall(filename=directory.replace(".json", "_average_scores.json"), doc_result=averages)
-        return eval_results
+        document_averages = self._compute_average_recall(document_eval_results)
+        question_averages = self._compute_average_recall(question_eval_results)
+        self._save_average_recall(filename=directory.replace(".json", "_average_scores.json"), doc_result=document_averages)
+        self._save_average_recall(filename=directory.replace(".json", "_question_average_scores.json"), doc_result=question_averages)
+        return document_eval_results
 
     def _retrieve(self, query: str, vector_db: VectorDB, answer: str, document_id: str) -> RetrieverResult:
         retriever_result = vector_db.retrieve(query=query)
@@ -87,9 +105,10 @@ class Service:
         return retrieved_paragraphs
 
     def _construct_dir(self, text_splitter) -> str:
-        return self.evaluator.evaluator_config.output_dir + f'/{current_datetime()}/chunk_size_{text_splitter.chunk_size}_{text_splitter.__class__.__name__}_{self.data_handler.__class__.__name__}.json'
+        return self.document_evaluator.evaluator_config.output_dir + f'/{current_datetime()}/chunk_size_{text_splitter.chunk_size}_{text_splitter.__class__.__name__}_{self.data_handler.__class__.__name__}.json'
 
-    def save(self, file_path: str, eval_result: EvalResult):
+    def _save_eval_result(self, file_path: str, eval_result: EvalResult):
+        """ Is used both for DocumentEvalResult and QuestionEvalResult. """
         create_dir_if_not_exists(file_path)
         # Read existing results
         try:
@@ -98,8 +117,9 @@ class Service:
         except (FileNotFoundError, json.JSONDecodeError):
             results = []
         # Append new result
-        saved_doc = eval_result.eval_sample.document
-        eval_result.eval_sample.document = "check ID for document"
+        if isinstance(eval_result, DocumentEvalResult):
+            saved_doc = eval_result.eval_sample.document
+            eval_result.eval_sample.document = "check ID for document"
         results.append(eval_result.model_dump())
         # Write back to the same JSON file
         with open(file_path, 'w') as f:
@@ -118,6 +138,7 @@ class Service:
             json.dump(doc_result.model_dump(), f, indent=4)
 
     def _compute_average_recall(self, eval_results: List[EvalResult]) -> AverageDocResult:
+        """Is used both for DocumentEvalResult and QuestionEvalResult."""
         list_of_recalls = [eval_result.recall_at_k for eval_result in eval_results]
         result = AverageDocResult(
             average_recall_at_k=mean_of_lists(list_of_recalls),
@@ -138,13 +159,15 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     splitter_configs = get_splitter_configs(chunk_sizes=args.chunk_sizes)
-    evaluator_config = EvaluatorConfig(eval_limit=args.eval_limit)
+    document_evaluator_config = DocumentEvaluatorConfig(eval_limit=args.eval_limit)
+    question_evaluator_config = QuestionEvaluatorConfig(eval_limit=args.eval_limit)
     data_handler_config = DataHandlerConfigFactory.create(args.data_handler_name)
     embed_model_config = EmbedModelConfig()
     vector_db_config = VectorDBConfig()
     service = Service(embed_model_config=embed_model_config,
                       splitter_configs=splitter_configs,
-                      evaluator_config=evaluator_config,
+                      document_evaluator_config=document_evaluator_config,
+                      question_evaluator_config=question_evaluator_config,
                       data_handler_config=data_handler_config,
                       vector_db_config=vector_db_config,
                       )

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -77,7 +77,7 @@ class Service:
                     sample.document_id,
                     question,
                     answer=answer.answer,
-                    retriever_result=retrieved_documents,
+                    retriever_result=retrieved_documents.paragraphs,
                     k=self.vector_db_config.similarity_top_k,
                 )
                 self._save_eval_result(eval_result=question_eval_result, file_path=directory.replace(".json", "_question_eval.json"))

--- a/test/evaluator/test_evaluator.py
+++ b/test/evaluator/test_evaluator.py
@@ -1,7 +1,7 @@
 import pytest
 
 from src.config.config import EvaluatorConfig
-from src.dto.dto import EvalResult, EvalSample, RetrieverResult, Answer
+from src.dto.dto import DocumentEvalResult, EvalSample, RetrieverResult, Answer
 from src.evaluator.evaluator import Evaluator
 
 
@@ -46,7 +46,7 @@ def test_evaluate(evaluator):
 
     result = evaluator.evaluate(eval_sample=eval_sample, retrieved_paragraphs=retrieved_paragraphs, k=5)
 
-    assert isinstance(result, EvalResult)
+    assert isinstance(result, DocumentEvalResult)
     assert result.recall_at_k == [1.0, 1.0, 1.0, 1.0, 1.0]
     assert result.eval_sample == eval_sample
     assert result.retriever_results == retrieved_paragraphs


### PR DESCRIPTION
I made it possible to calculate recall at k per question (in addition to by document).

1. It is now integrated in the general evaluation pipeline (1. commit)
2. It is also possible to calculate them for already existing evaluations (2. commit)

Once we have all the evaluation jsons on sharepoint, I can run the post evaluations on them.

I hope this is more or less how you wanted to implement within the project structure.